### PR TITLE
Scenario manager for technology configs and Snakemake workflow

### DIFF
--- a/Exclusion.py
+++ b/Exclusion.py
@@ -13,6 +13,7 @@ import yaml
 from utils.data_preprocessing import clean_region_name, log_scenario_run
 from rasterstats import zonal_stats
 from utils.raster_analysis import area_filter, overlay_value_raster
+from utils.tech_config import load_tech_config
 
 # Record the starting time
 start_time = time.time()
@@ -55,9 +56,7 @@ else:
 
 
 # load the technology specific configuration file
-tech_config_file = os.path.join("configs", f"{technology}.yaml")
-with open(tech_config_file, "r", encoding="utf-8") as f:
-    tech_config = yaml.load(f, Loader=yaml.FullLoader)
+tech_config = load_tech_config(technology, scenario)
 
 resampled = ""  #'_resampled'
 
@@ -665,7 +664,7 @@ print(f"elapsed time: {elapsed}")
 # save info in textfile
 with open(
     os.path.join(
-        output_dir, f"{region_name_clean}_{scenario}_{technology}_exclusion_info.txt"
+        output_dir, f"{region_name_clean}_{technology}_{scenario}_exclusion_info.txt"
     ),
     "w",
 ) as file:
@@ -706,7 +705,7 @@ if config["model_areas_filename"]:
 with open(
     os.path.join(
         output_dir,
-        f"{region_name_clean}_{scenario}_{technology}_exclusion_info.json",
+        f"{region_name_clean}_{technology}_{scenario}_exclusion_info.json",
     ),
     "w",
 ) as file:

--- a/configs/config_snakemake.yaml
+++ b/configs/config_snakemake.yaml
@@ -2,7 +2,7 @@
 #region parameters.
 
 study_region_name: [Odense, Ringsted]
-scenario: [ref]
+scenarios: [ref]
 technologies: [solar]
 
 #snakemake specific parameters

--- a/configs/config_snakemake.yaml
+++ b/configs/config_snakemake.yaml
@@ -1,7 +1,7 @@
 # General
 #region parameters.
 
-study_region_name: [Odense, Ringsted]
+study_region_name: [Odense]
 scenarios: [ref]
 technologies: [solar]
 
@@ -11,7 +11,7 @@ snakefile: snakemake/Snakefile
 weather_years: [2019]
 
 stages:
-  spatial_data_prep: true
+  spatial_data_prep: false
   exclusion: true
   suitability: false
   timeseries: false

--- a/configs/examples/config_snakemake_template_china.yaml
+++ b/configs/examples/config_snakemake_template_china.yaml
@@ -1,8 +1,8 @@
 # General
 #region parameters.
 
-study_region_name: Beijing 
-scenario: new-smk-test
+study_region_name: [Beijing]
+scenarios: [new-smk-test]
 technologies: ['onshorewind'] #onshorewind or solar
 
 #snakemake specific parameters

--- a/configs/onshorewind_template.yaml
+++ b/configs/onshorewind_template.yaml
@@ -11,8 +11,7 @@ projection_manual: null # e.g. 'ESRI:54009' Mollweide (if used, then resolution 
 
 #landcover codes (buffer in meters) (here landcover codes for openeo as default example)
 landcover_codes: #dictionary of landcover code with corresponding buffer in meters
-  50: 100
-  10: 0
+  50: 0
 
 #landcover codes (buffer in meters) (here landcover codes for openeo as default example)
 #| Code | Class                    |
@@ -76,7 +75,9 @@ min_pixels_connected: 0
 min_pixels_x: # currently not working, use min_pixels_connected instead
 min_pixels_y: # currently not working, use min_pixels_connected instead
 
+
 # add additional scenarios, e.g. strictrailways to override ref scenario values
+# scenario names cannot have any special characters or spaces, only letters
 additional_scenarios:
   strictrailways:
     railways_buffer: 500

--- a/configs/onshorewind_template.yaml
+++ b/configs/onshorewind_template.yaml
@@ -76,6 +76,7 @@ min_pixels_connected: 0
 min_pixels_x: # currently not working, use min_pixels_connected instead
 min_pixels_y: # currently not working, use min_pixels_connected instead
 
+# add additional scenarios, e.g. strictrailways to override ref scenario values
 additional_scenarios:
-  relaxed_roads:
-    roads_buffer: 50
+  strictrailways:
+    railways_buffer: 500

--- a/configs/onshorewind_template.yaml
+++ b/configs/onshorewind_template.yaml
@@ -1,3 +1,5 @@
+reference_scenario: ref
+
 #--exclusions----------------------------------------------------------------------
 
 # deployment density
@@ -73,3 +75,7 @@ roads_inclusion_buffer: null
 min_pixels_connected: 0
 min_pixels_x: # currently not working, use min_pixels_connected instead
 min_pixels_y: # currently not working, use min_pixels_connected instead
+
+additional_scenarios:
+  relaxed_roads:
+    roads_buffer: 50

--- a/configs/solar_template.yaml
+++ b/configs/solar_template.yaml
@@ -11,7 +11,7 @@ projection_manual: Null # e.g. 'ESRI:54009' Mollweide (if used, then resolution 
 
 #landcover codes (buffer in meters) (here landcover codes for openeo as default example)
 landcover_codes: #dictionary of landcover code with corresponding buffer in meters
-  50: 100
+  50: 0
 
 #landcover codes (buffer in meters) (here landcover codes for openeo as default example)
 #| Code | Class                    |
@@ -75,7 +75,9 @@ min_pixels_connected: 0
 min_pixels_x: # currently not working, use min_pixels_connected instead
 min_pixels_y: # currently not working, use min_pixels_connected instead
 
+
 # add additional scenarios, e.g. strictrailways to override ref scenario values
+# scenario names cannot have any special characters or spaces, only letters
 additional_scenarios:
   strictrailways:
     railways_buffer: 500

--- a/configs/solar_template.yaml
+++ b/configs/solar_template.yaml
@@ -1,3 +1,5 @@
+reference_scenario: ref
+
 #--exclusions------------------Odense default: 16.98%, 51.90km²---------------------------------------------
 
 # deployment density
@@ -72,3 +74,7 @@ roads_inclusion_buffer: null
 min_pixels_connected: 0
 min_pixels_x: # currently not working, use min_pixels_connected instead
 min_pixels_y: # currently not working, use min_pixels_connected instead
+
+additional_scenarios:
+  relaxed_roads:
+    roads_buffer: 50

--- a/configs/solar_template.yaml
+++ b/configs/solar_template.yaml
@@ -75,6 +75,7 @@ min_pixels_connected: 0
 min_pixels_x: # currently not working, use min_pixels_connected instead
 min_pixels_y: # currently not working, use min_pixels_connected instead
 
+# add additional scenarios, e.g. strictrailways to override ref scenario values
 additional_scenarios:
-  relaxed_roads:
-    roads_buffer: 50
+  strictrailways:
+    railways_buffer: 500

--- a/docs/home/basic_workflow.md
+++ b/docs/home/basic_workflow.md
@@ -23,6 +23,7 @@ tool on a new study region. The steps below assume that you have already cloned 
 In the **configs-folder** copy the file `config_template.yaml`, rename it to `config.yaml` and fill it out. This is your main configuration file for the data download.
 
 For the exclusion criterias copy the files `onshorewind_template.yaml` and `solar_template.yaml`. Rename them to `onshorewind.yaml` and `solar.yaml` respectively. Fill these files out in order to set the exclusion parameters.
+The top-level values in each technology file define the reference scenario. Use `reference_scenario` to name that base case and `additional_scenarios` to define only the values that change in other scenarios.
 
 !!! note 
     An overview of possible exclusion criterias found in selected literature can be downloaded [here](../assets/literature_overview.xlsx).
@@ -52,10 +53,10 @@ Create technology-specific available-land rasters by running `Exclusion.py`. The
 flags must provide the study region, technology, and scenario so that single runs can be processed
 independently. There are configuration files for the land exclusion for wind onshore and utility-scale solar PV.
 ```bash
-python Exclusion.py --technology solar --scenario ref --region Odense
+python Exclusion.py --technology solar --scenario <ScenarioName> --region Odense
 ```
 ```bash
-python Exclusion.py --technology onshorewind --scenario ref --region Odense
+python Exclusion.py --technology onshorewind --scenario <ScenarioName> --region Odense
 ```
 
 The script loads the prepared rasters and vector layers, applies the filters defined in the
@@ -68,7 +69,7 @@ for traceability.
 
 ## Batch processing with Snakemake
 
-When analysing multiple study regions, you can use a snakemake workflow to automatically execute all scripts for all regions one after another. Adjust `config_snakemake.yaml` and run the batch job with the following comamand in the terminal:
+When analysing multiple study regions, you can use a snakemake workflow to automatically execute all scripts for all regions one after another. Adjust `config_snakemake.yaml`, especially the `scenarios` list, and run the batch job with the following comamand in the terminal:
 ```bash
 snakemake -s snakemake/Snakefile --cores 1 --resources openeo_req=1
 ```

--- a/docs/home/full_workflow.md
+++ b/docs/home/full_workflow.md
@@ -16,6 +16,7 @@ tool on a new study region.
 In the **configs-folder** copy the file `config_template.yaml`, rename it to `config.yaml` and fill it out. This is your main configuration file for the data download.
 
 For the exclusion criterias copy the files `onshorewind_template.yaml` and `solar_template.yaml`. Rename them to `onshorewind.yaml` and `solar.yaml` respectively. Fill these files out in order to set the exclusion parameters.
+The top-level values in each technology file define the reference scenario. Use `reference_scenario` to set its name and `additional_scenarios` to store only the changed values for additional scenarios.
 
 ## Prepare spatial data
 
@@ -48,8 +49,8 @@ Create technology-specific available-land rasters by running `Exclusion.py`. The
 flags mirror the configuration entries so that single technologies or scenarios can be processed
 independently.
 ```bash
-python Exclusion.py --technology onshorewind --scenario ref --region <RegionName>
-python Exclusion.py --technology solar --scenario ref --region <RegionName>
+python Exclusion.py --technology onshorewind --scenario <ScenarioName> --region <RegionName>
+python Exclusion.py --technology solar --scenario <ScenarioName> --region <RegionName>
 ```
 
 The script loads the prepared rasters and vector layers, applies the filters defined in the
@@ -63,7 +64,7 @@ Run `suitability.py` after both solar and wind exclusions are available. The scr
 resource layers, applies terrain and region modifiers, and exports cost multipliers together with
 thresholded resource-grade rasters in `data/<RegionName>/suitability/`.
 ```bash
-python suitability.py --region <RegionName> --scenario ref
+python suitability.py --region <RegionName> --scenario <ScenarioName>
 ```
 
 ## Energy profile simulation
@@ -72,8 +73,8 @@ Energy profiles combine the available land, suitability grades, and weather cut-
 `configs/config.yaml` points `weather_data_path` to the directory that contains the prepared
 atlite cut-outs. Then run:
 ```bash
-python energy_profiles.py --region <RegionName> --technology onshorewind --scenario ref --weather_year 2019
-python energy_profiles.py --region <RegionName> --technology solar --scenario ref --weather_year 2019
+python energy_profiles.py --region <RegionName> --technology onshorewind --scenario <ScenarioName> --weather_year 2019
+python energy_profiles.py --region <RegionName> --technology solar --scenario <ScenarioName> --weather_year 2019
 ```
 
 Outputs are written to `data/<RegionName>/energy_profiles/` and include resource-grade time series
@@ -82,8 +83,8 @@ as well as diagnostic plots documenting the available area shares.
 ## Batch processing with Snakemake
 
 For large-scale studies the `snakemake/Snakefile` orchestrates all stages across multiple regions,
-technologies, and weather years. The workflow creates `snakemake_log` sentinels to prevent reruns
-of completed steps. Launch it (after customising the region lists at the top of the Snakefile) with:
+technologies, scenarios, and weather years. The workflow creates `snakemake_log` sentinels to prevent reruns
+of completed steps. Launch it after customising `config_snakemake.yaml`, including the `scenarios` list:
 ```bash
 snakemake --cores 4 --resources openeo_req=1
 ```

--- a/energy_profiles.py
+++ b/energy_profiles.py
@@ -12,6 +12,7 @@ from utils.data_preprocessing import clean_region_name, rel_path
 import pickle
 import argparse
 import glob
+from utils.tech_config import load_tech_config
 
 # ------------------------------------------- Load configuration
 dirname = os.getcwd()
@@ -20,31 +21,30 @@ with open(os.path.join("configs/config.yaml"), "r", encoding="utf-8") as f:
 
 region_name = config["study_region_name"]
 region_name = clean_region_name(region_name)
-technology = config["technology"]
-scenario = config.get("scenario", "ref")  # scenario, e.g., 'ref' or 'high'
 weather_year = config["weather_year"]
 
 # override values via command line arguments through snakemake
 parser = argparse.ArgumentParser()
 parser.add_argument("--region", default=region_name, help="region name")
-parser.add_argument("--technology", default=technology, help="technology type")
+parser.add_argument("--technology", required=True, help="technology type")
 parser.add_argument(
     "--method",
     default="manual",
     help="method to run the script, e.g., snakemake or manual",
 )
-parser.add_argument("--scenario", default=scenario, help="scenario name")
+parser.add_argument("--scenario", required=True, help="scenario name")
 parser.add_argument(
     "--weather_year", default=weather_year, help="weather year for the energy profiles"
 )
 args = parser.parse_args()
 
+region_name = clean_region_name(args.region)
+technology = args.technology
+scenario = args.scenario
+weather_year = args.weather_year
+
 # If running via Snakemake, use the region name and folder name from command line arguments
 if args.method == "snakemake":
-    region_name = args.region
-    technology = args.technology
-    scenario = args.scenario
-    weather_year = args.weather_year
     print(
         f"Running via snakemake - measures: region={region_name}, technology={technology}, scenario={scenario}, weather_year={weather_year}"
     )
@@ -54,9 +54,7 @@ else:
     )
 
 # load the technology specific configuration file
-tech_config_file = os.path.join("configs", f"{technology}.yaml")
-with open(tech_config_file, "r", encoding="utf-8") as f:
-    tech_config = yaml.load(f, Loader=yaml.FullLoader)
+tech_config = load_tech_config(technology, scenario)
 
 data_path = os.path.join(dirname, "data", region_name)
 output_path = os.path.join(data_path, "energy_profiles")

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -1,6 +1,7 @@
 from pathlib import Path
 import json
 import yaml
+from utils.tech_config import validate_selected_scenarios
 
 
 
@@ -11,8 +12,10 @@ with open("configs/config_snakemake.yaml", "r", encoding="utf-8") as f:
 #define parameters , keep them in list as it iterates, multiple input can be included. 
 regions = config_snakemake["study_region_name"]
 technologies = config_snakemake["technologies"]
-scenario= config_snakemake["scenario"]
+scenarios = config_snakemake["scenarios"]
 weather_years = config_snakemake["weather_years"]
+
+validate_selected_scenarios(technologies, scenarios)
 
 def logpath(region, filename):
     return Path("data") / region / "snakemake_log" / filename
@@ -58,15 +61,14 @@ if DO_EXCLUSION:
         logpath("{region}", "exclusion_{technology}_{scenario}.done"),
         region=regions,
         technology=technologies,
-        scenario=scenario,
+        scenario=scenarios,
     )
 
 if DO_SUITABILITY:
     ALL_TARGETS += expand(
-        logpath("{region}", "suitability_{technology}_{scenario}.done"),
+        logpath("{region}", "suitability_{scenario}.done"),
         region=regions,
-        technology=technologies,
-        scenario=scenario,
+        scenario=scenarios,
     )
 
 if DO_TIMESERIES:
@@ -75,7 +77,7 @@ if DO_TIMESERIES:
         region=regions,
         technology=technologies,
         weather_year=weather_years,
-        scenario=scenario,
+        scenario=scenarios,
     )
 
 
@@ -96,7 +98,7 @@ if DO_ENERGY_PROFILES:
     ALL_TARGETS += expand(
         logpath("{region}", "energy_profiles_{technology}_{weather_year}_{scenario}.done"),
         region=regions,
-        scenario=scenario,
+        scenario=scenarios,
         technology=technologies,
         weather_year=weather_years,
     )

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -1,6 +1,12 @@
 from pathlib import Path
+import sys
 import json
 import yaml
+
+PROJECT_ROOT = Path.cwd()
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from utils.tech_config import validate_selected_scenarios
 
 

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -64,7 +64,10 @@ if DO_SPATIAL_DATA_PREP:
 
 if DO_EXCLUSION:
     ALL_TARGETS += expand(
-        logpath("{region}", "exclusion_{technology}_{scenario}.done"),
+        Path("data")
+        / "{region}"
+        / "available_land"
+        / "{region}_{technology}_{scenario}_available_land.tif",
         region=regions,
         technology=technologies,
         scenario=scenarios,

--- a/snakemake/rules/energy_profiles.smk
+++ b/snakemake/rules/energy_profiles.smk
@@ -4,13 +4,12 @@ rule energy_profiles:
     output:
         touch(logpath("{region}", "energy_profiles_{technology}_{weather_year}_{scenario}.done"))
     params:
-        method="snakemake", 
-        scenario=scenario
+        method="snakemake"
     shell:
         (
             "python energy_profiles.py --region {wildcards.region} "
             "--technology {wildcards.technology} "
             "--weather_year {wildcards.weather_year} "
             "--method {params.method} "
-            "--scenario {params.scenario} "
+            "--scenario {wildcards.scenario} "
         )

--- a/snakemake/rules/exclusion.smk
+++ b/snakemake/rules/exclusion.smk
@@ -4,10 +4,9 @@ rule exclusion:
     output:
         touch(logpath("{region}", "exclusion_{technology}_{scenario}.done"))
     params:
-        method="snakemake",
-        scenario=scenario 
+        method="snakemake"
     shell:
         (
             "python Exclusion.py --region {wildcards.region} "
-            "--technology {wildcards.technology} --method {params.method} --scenario {params.scenario}"
+            "--technology {wildcards.technology} --method {params.method} --scenario {wildcards.scenario}"
         )

--- a/snakemake/rules/exclusion.smk
+++ b/snakemake/rules/exclusion.smk
@@ -1,6 +1,9 @@
 rule exclusion:
     output:
-        touch(logpath("{region}", "exclusion_{technology}_{scenario}.done"))
+        Path("data")
+        / "{region}"
+        / "available_land"
+        / "{region}_{technology}_{scenario}_available_land.tif"
     params:
         method="snakemake"
     shell:

--- a/snakemake/rules/exclusion.smk
+++ b/snakemake/rules/exclusion.smk
@@ -1,6 +1,4 @@
 rule exclusion:
-    input:
-        logpath("{region}", "spatial_data_prep.done")
     output:
         touch(logpath("{region}", "exclusion_{technology}_{scenario}.done"))
     params:

--- a/snakemake/rules/suitability.smk
+++ b/snakemake/rules/suitability.smk
@@ -1,10 +1,14 @@
 rule suitability:
     input:
-        expand(logpath("{region}", "exclusion_{technology}_{scenario}.done"), region=regions, technology=technologies, scenario=scenario)
+        lambda wildcards: expand(
+            logpath("{region}", "exclusion_{technology}_{scenario}.done"),
+            region=[wildcards.region],
+            technology=technologies,
+            scenario=[wildcards.scenario],
+        )
     output:
         touch(logpath("{region}", "suitability_{scenario}.done"))
     params:
-        method="snakemake",
-        scenario=scenario
+        method="snakemake"
     shell:
-        "python suitability.py --region {wildcards.region} --method {params.method} --scenario {params.scenario}"
+        "python suitability.py --region {wildcards.region} --method {params.method} --scenario {wildcards.scenario}"

--- a/snakemake/rules/suitability.smk
+++ b/snakemake/rules/suitability.smk
@@ -1,7 +1,10 @@
 rule suitability:
     input:
         lambda wildcards: expand(
-            logpath("{region}", "exclusion_{technology}_{scenario}.done"),
+            Path("data")
+            / "{region}"
+            / "available_land"
+            / "{region}_{technology}_{scenario}_available_land.tif",
             region=[wildcards.region],
             technology=technologies,
             scenario=[wildcards.scenario],

--- a/suitability.py
+++ b/suitability.py
@@ -19,6 +19,7 @@ from utils.raster_analysis import (
     overlap,
     rasterize,
 )
+from utils.tech_config import load_tech_config
 
 
 # ------------------------------------------- Initialization -------------------------------------------
@@ -31,23 +32,10 @@ suitability_config_file = os.path.join("configs", "suitability.yaml")
 with open(suitability_config_file, "r", encoding="utf-8") as f:
     config_suitability = yaml.load(f, Loader=yaml.FullLoader)
 
-# Load the configs for relevant technologies
-suitability_techs = config_suitability["suitability_techs"]
-tech_configs = {}
-for tech in suitability_techs:
-    tech_config_file = os.path.join("configs", f"{tech}.yaml")
-    with open(tech_config_file, "r", encoding="utf-8") as f:
-        tech_configs[tech] = yaml.load(f, Loader=yaml.FullLoader)
-if len(suitability_techs) > 1:
-    multi_tech = True
-else:
-    multi_tech = False
-
 region_name = config[
     "study_region_name"
 ]  # if country is studied, then use country name
 region_name = clean_region_name(region_name)
-scenario = config["scenario"]
 
 # Initialize parser for command line arguments and define arguments
 parser = argparse.ArgumentParser()
@@ -57,13 +45,24 @@ parser.add_argument(
     default="manual",
     help="method to run the script, e.g., snakemake or manual",
 )
-parser.add_argument("--scenario", default=scenario, help="scenario name")
+parser.add_argument("--scenario", required=True, help="scenario name")
 args = parser.parse_args()
+
+region_name = clean_region_name(args.region)
+scenario = args.scenario
+
+# Load the configs for relevant technologies
+suitability_techs = config_suitability["suitability_techs"]
+tech_configs = {}
+for tech in suitability_techs:
+    tech_configs[tech] = load_tech_config(tech, scenario)
+if len(suitability_techs) > 1:
+    multi_tech = True
+else:
+    multi_tech = False
 
 # If running via Snakemake, use the region name and folder name from command line arguments
 if args.method == "snakemake":
-    region_name = clean_region_name(args.region)
-    scenario = args.scenario
     print(
         f"Running via snakemake - measures: region={region_name}, scenario={scenario}"
     )

--- a/timeseries.py
+++ b/timeseries.py
@@ -56,8 +56,8 @@ with open(os.path.join(dirname, "configs/config.yaml"), "r", encoding="utf-8") a
 parser = argparse.ArgumentParser()
 parser.add_argument("--region", default=config["study_region_name"])
 parser.add_argument("--weather_year", default=config["weather_year"], type=int)
-parser.add_argument("--scenario", default=config.get("scenario", "ref"))
-parser.add_argument("--technology", default=config.get("technology", "solar"))
+parser.add_argument("--scenario", required=True)
+parser.add_argument("--technology", required=True)
 args = parser.parse_args()
 
 study_region_name = clean_region_name(args.region)

--- a/utils/tech_config.py
+++ b/utils/tech_config.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import copy
+import os
+from typing import Any
+
+import yaml
+
+
+def _deep_merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for key, value in override.items():
+        if isinstance(merged.get(key), dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_dicts(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _load_yaml_file(file_path: str) -> dict[str, Any]:
+    with open(file_path, "r", encoding="utf-8") as file:
+        return yaml.load(file, Loader=yaml.FullLoader)
+
+
+def _split_scenario_sections(
+    raw_config: dict[str, Any],
+) -> tuple[str, dict[str, Any], dict[str, dict[str, Any]]]:
+    reference_scenario = raw_config.get("reference_scenario", "ref")
+    additional_scenarios = copy.deepcopy(raw_config.get("additional_scenarios") or {})
+    base_config = copy.deepcopy(raw_config)
+    base_config.pop("reference_scenario", None)
+    base_config.pop("additional_scenarios", None)
+
+    if reference_scenario in additional_scenarios:
+        raise ValueError(
+            f"Scenario override '{reference_scenario}' conflicts with reference_scenario. "
+            "Use the top-level config as the reference scenario and keep only non-reference scenarios under additional_scenarios."
+        )
+
+    return reference_scenario, base_config, additional_scenarios
+
+
+def load_tech_config_from_path(file_path: str, scenario: str | None) -> dict[str, Any]:
+    raw_config = _load_yaml_file(file_path)
+    reference_scenario, base_config, additional_scenarios = _split_scenario_sections(
+        raw_config
+    )
+
+    if scenario is None or scenario == reference_scenario:
+        return base_config
+
+    if scenario not in additional_scenarios:
+        valid_scenarios = [reference_scenario, *additional_scenarios.keys()]
+        raise KeyError(
+            f"Scenario '{scenario}' is not defined in {os.path.basename(file_path)}. "
+            f"Available scenarios: {valid_scenarios}"
+        )
+
+    return _deep_merge_dicts(base_config, additional_scenarios[scenario])
+
+
+def load_tech_config(
+    technology: str, scenario: str | None, config_dir: str = "configs"
+) -> dict[str, Any]:
+    file_path = os.path.join(config_dir, f"{technology}.yaml")
+    return load_tech_config_from_path(file_path, scenario)
+
+
+def get_tech_scenarios_from_path(file_path: str) -> list[str]:
+    raw_config = _load_yaml_file(file_path)
+    reference_scenario, _, additional_scenarios = _split_scenario_sections(raw_config)
+    return [reference_scenario, *additional_scenarios.keys()]
+
+
+def get_tech_scenarios(technology: str, config_dir: str = "configs") -> list[str]:
+    file_path = os.path.join(config_dir, f"{technology}.yaml")
+    return get_tech_scenarios_from_path(file_path)
+
+
+def validate_selected_scenarios(
+    technologies: list[str], scenarios: list[str], config_dir: str = "configs"
+) -> None:
+    invalid: dict[str, list[str]] = {}
+
+    for technology in technologies:
+        available_scenarios = set(get_tech_scenarios(technology, config_dir=config_dir))
+        missing = [
+            scenario for scenario in scenarios if scenario not in available_scenarios
+        ]
+        if missing:
+            invalid[technology] = missing
+
+    if invalid:
+        lines = [
+            f"{technology}: missing scenarios {missing}"
+            for technology, missing in invalid.items()
+        ]
+        raise ValueError(
+            "Selected Snakemake scenarios are not defined in the technology configs:\n"
+            + "\n".join(lines)
+        )


### PR DESCRIPTION
This PR adds scenario management for exclusion workflows, with reference scenarios in technology config files and optional per-scenario overrides.

### What changed
1. Added scenario config loader and validation utilities in `utils/tech_config.py`:
- Loads technology configs using `reference_scenario` + `additional_scenarios`
- Merges scenario overrides into reference values
- Validates selected Snakemake scenarios against available technology scenarios

2. Updated exclusion and downstream scripts to use scenario-aware configs:
- `Exclusion.py`
- `suitability.py`
- `energy_profiles.py`
- `timeseries.py`

3. Updated Snakemake scenario selection and rule wiring:
- Switched config list key to `scenarios` in `configs/config_snakemake.yaml`
- Added scenario validation and workflow import path fix in `snakemake/Snakefile`
- Updated scenario wildcard passing in:
  - `snakemake/rules/exclusion.smk`
  - `snakemake/rules/suitability.smk`
  - `snakemake/rules/timeseries.smk`
  - `snakemake/rules/energy_profiles.smk`

4. Changed exclusion stage to use real raster outputs instead of exclusion done sentinels:
- Exclusion output target is now:
  `data/{region}/available_land/{region}_{technology}_{scenario}_available_land.tif`

5. Standardized exclusion info output naming to `region_technology_scenario` ordering in `Exclusion.py`

6. Updated templates and docs for the new scenario pattern:
- `configs/solar_template.yaml`
- `configs/onshorewind_template.yaml`
- `docs/home/basic_workflow.md`
- `docs/home/full_workflow.md`

7. Added scenario examples in templates:
- `additional_scenarios` with `strictrailways` example overriding `railways_buffer`

### Validation
- Python compile check passed for updated scripts:
  `Exclusion.py`, `suitability.py`, `energy_profiles.py`, `timeseries.py`, `utils/tech_config.py`
- Snakemake file linting in editor shows no errors in updated workflow files.